### PR TITLE
ECS起動時のいくつかの問題を解消した

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,8 +1,8 @@
 resource "aws_cloudwatch_log_group" "daily_report_system" {
-  name              = "daily_report_system"
+  name              = "/daily_report_system"
   retention_in_days = 1
 
   tags = {
-    Environment = "dev"
+    Environment = "prod"
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -47,11 +47,10 @@ resource "aws_ecs_task_definition" "daily_report_system" {
       secrets = [
         {
           name      = "SECRET_KEY_BASE",
-          valueFrom = "${aws_secretsmanager_secret.secret_key_base.arn}:SECRET_KEY_BASE::"
+          valueFrom = "arn:aws:secretsmanager:${var.aws_region}:${var.kk_account_id}:secret:${aws_secretsmanager_secret.secret_key_base.name}:SECRET_KEY_BASE::"
         }
       ]
-      command = ["sh", "-c", "echo hello world && sleep 3600"]
-      # command = ["bundle", "exec", "rails", "-v"]
+      command = ["bundle", "exec", "rails", "-v"]
       logConfiguration = {
         logDriver = "awslogs"
         options = {
@@ -66,7 +65,7 @@ resource "aws_ecs_task_definition" "daily_report_system" {
 
   runtime_platform {
     operating_system_family = "LINUX"
-    cpu_architecture        = "ARM64"
+    cpu_architecture        = "X86_64"
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -88,11 +88,17 @@ resource "aws_iam_role_policy" "ecs_task_exec_secret" {
       {
         Effect = "Allow",
         Action = [
-          "secretsmanager:GetSecretValue"
+          "secretsmanager:GetSecretValue",
+          "ssm:GetParameters"
         ],
         Resource = [
-          "arn:aws:secretsmanager:${var.aws_region}:${var.kk_account_id}:secret:prod/drs/*"
+          "arn:aws:secretsmanager:${var.aws_region}:${var.kk_account_id}:secret:prod/drs/*",
         ]
+      },
+      {
+        Effect   = "Allow",
+        Action   = "kms:Decrypt",
+        Resource = "*"
       }
     ]
   })

--- a/kms.tf
+++ b/kms.tf
@@ -34,6 +34,19 @@ resource "aws_kms_key_policy" "symmetric" {
         ]
         Resource = "*"
       },
+      {
+        Sid    = "Allow ECS to use this key"
+        Effect = "Allow"
+        Principal = {
+          AWS = aws_iam_role.ecs_task_execution.arn
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey"
+        ]
+        Resource = "*"
+      }
     ]
     Version = "2012-10-17"
   })

--- a/vpc.tf
+++ b/vpc.tf
@@ -28,6 +28,16 @@ resource "aws_route_table" "main" {
   }
 }
 
+resource "aws_route_table_association" "private_1a" {
+  subnet_id      = aws_subnet.private["private-ne-1a"].id
+  route_table_id = aws_route_table.main.id
+}
+
+resource "aws_route_table_association" "private_1c" {
+  subnet_id      = aws_subnet.private["private-ne-1c"].id
+  route_table_id = aws_route_table.main.id
+}
+
 resource "aws_security_group" "ecr_dkr" {
   description = "For VPC Endpoint of ecr.dkr"
   vpc_id      = aws_vpc.main.id
@@ -177,3 +187,36 @@ resource "aws_vpc_endpoint" "s3" {
   }
 }
 
+resource "aws_vpc_endpoint" "logs" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.ap-northeast-1.logs"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = [
+    aws_subnet.private["private-ne-1a"].id,
+    aws_subnet.private["private-ne-1c"].id
+  ]
+
+  private_dns_enabled = true
+
+  tags = {
+    Name = "logs-${local.name_suffix}"
+  }
+}
+
+resource "aws_vpc_endpoint" "secret_manager" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.ap-northeast-1.secretsmanager"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = [
+    aws_subnet.private["private-ne-1a"].id,
+    aws_subnet.private["private-ne-1c"].id
+  ]
+
+  private_dns_enabled = true
+
+  tags = {
+    Name = "secret-manager-${local.name_suffix}"
+  }
+}


### PR DESCRIPTION
closes #27 

# 問題点と解決策
## `SecretsManager`から秘匿情報を取得できない
- `Subnet`に関連づけられたルートテーブルがないので、サブネット内のECSタスクとVPCエンドポイントGatewayがつながっていなかった
- `SecretsManager`で使用しているCMKについて、ECSタスク実行ロールの権限が足りていなかった

## 軌道に失敗した
- `GHA workflow`ではamd64でビルドしているが、`FARGATE`はarm64だったので、失敗した
  - `FARGATE`を`x86_64`で起動するように修正した
